### PR TITLE
feat(program): Implement course and rate limit functionality

### DIFF
--- a/school/programs/school/src/constants.rs
+++ b/school/programs/school/src/constants.rs
@@ -8,7 +8,7 @@ pub enum SchoolType {
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Eq)]
-pub struct NftMetaDataAttributes {
+pub struct CreateNFTParams {
     pub name: String,
     pub symbol: String,
     pub uri: String,

--- a/school/programs/school/src/error.rs
+++ b/school/programs/school/src/error.rs
@@ -19,3 +19,9 @@ pub enum SchoolError {
     #[msg("Invalid school type")]
     InvalidSchoolType,
 }
+
+#[error_code]
+pub enum CourseError {
+    #[msg("Name is too short")]
+    InvalidName,
+}

--- a/school/programs/school/src/instructions/course.rs
+++ b/school/programs/school/src/instructions/course.rs
@@ -1,0 +1,20 @@
+use anchor_lang::prelude::*;
+
+use crate::{Course, RateLimit, School, SchoolTrait};
+
+#[derive(Accounts)]
+#[instruction(name: String, school_bump: u8)]
+pub struct InitializesCourse<'info> {
+    #[account(init, payer=authority, space= 8 + 32 + 8 + 4, seeds=[b"course", name.as_bytes(), school.key().as_ref(), authority.key().as_ref()], bump)]
+    pub course: Account<'info, Course>,
+    #[account(mut)]
+    authority: Signer<'info>,
+    #[account(seeds=[b"school", authority.key().as_ref(), &school.get_school_type().as_bytes()], bump = school_bump)]
+    pub school: Account<'info, School>,
+    pub system_program: Program<'info, System>,
+    #[account(
+        mut, seeds= [b"rate_limit", authority.key().as_ref()], bump
+    )]
+    pub rate_limit: Account<'info, RateLimit>,
+    pub rent: Sysvar<'info, Rent>,
+}

--- a/school/programs/school/src/instructions/mod.rs
+++ b/school/programs/school/src/instructions/mod.rs
@@ -1,5 +1,7 @@
+pub mod course;
 pub mod mintnft;
 pub mod school;
 
+pub use course::*;
 pub use mintnft::*;
 pub use school::*;

--- a/school/programs/school/src/instructions/school.rs
+++ b/school/programs/school/src/instructions/school.rs
@@ -1,6 +1,8 @@
 use anchor_lang::prelude::*;
 
-use crate::{constants::SchoolType, error::SchoolError, School, SchoolTrait};
+use crate::{
+    constants::SchoolType, error::SchoolError, utils::SchoolTypeTrait, School, SchoolTrait,
+};
 
 #[derive(Accounts)]
 #[instruction(school_type: String)]
@@ -19,12 +21,9 @@ pub fn initialize_school(
     school_type: String,
     fee_multiplier: u64,
 ) -> Result<()> {
-    let school_type = match school_type.as_str() {
-        "HighSchool" => SchoolType::HighSchool,
-        "College" => SchoolType::College,
-        "University" => SchoolType::University,
-        _ => return Err(SchoolError::InvalidSchoolType.into()),
-    };
+    if !SchoolType::is_school_type(&school_type)? {
+        return Err(SchoolError::InvalidSchoolType.into());
+    }
     let school = &mut ctx.accounts.school;
     school.set_authority(ctx.accounts.authority.key());
     school.set_enrollment_fee(enrollment_fee);

--- a/school/programs/school/src/lib.rs
+++ b/school/programs/school/src/lib.rs
@@ -4,6 +4,7 @@ pub mod constants;
 pub mod error;
 pub mod instructions;
 pub mod state;
+pub mod utils;
 
 use instructions::*;
 use state::*;
@@ -25,6 +26,3 @@ pub mod school {
         instructions::initialize_school(ctx, enrollment_fee, name, school_type, fee_multiplier)
     }
 }
-
-#[derive(Accounts)]
-pub struct Initialize {}

--- a/school/programs/school/src/state/course.rs
+++ b/school/programs/school/src/state/course.rs
@@ -14,18 +14,6 @@ pub struct Course {
 }
 
 pub trait CourseTrait {
-    fn new(
-        name: String,
-        nft_mint: Pubkey,
-        capacity: u32,
-        enrolled_students_count: u32,
-        tutuion_fee: u64,
-        school: Pubkey,
-        authority: Pubkey,
-        nft_token_account: Pubkey,
-        bump: u8,
-    ) -> Self;
-
     fn get_name(&self) -> &str;
     fn get_nft_mint(&self) -> Pubkey;
     fn get_capacity(&self) -> u32;
@@ -47,30 +35,6 @@ pub trait CourseTrait {
 }
 
 impl CourseTrait for Course {
-    fn new(
-        name: String,
-        nft_mint: Pubkey,
-        capacity: u32,
-        enrolled_students_count: u32,
-        tutuion_fee: u64,
-        school: Pubkey,
-        authority: Pubkey,
-        nft_token_account: Pubkey,
-        bump: u8,
-    ) -> Self {
-        Course {
-            name,
-            nft_mint,
-            nft_token_account,
-            capacity,
-            enrolled_students_count,
-            tutuion_fee,
-            school,
-            authority,
-            bump,
-        }
-    }
-
     fn get_name(&self) -> &str {
         &self.name
     }

--- a/school/programs/school/src/state/mod.rs
+++ b/school/programs/school/src/state/mod.rs
@@ -1,7 +1,9 @@
 pub mod course;
+pub mod nft;
 pub mod ratelimit;
 pub mod school;
 
 pub use course::*;
+pub use nft::*;
 pub use ratelimit::*;
 pub use school::*;

--- a/school/programs/school/src/state/nft.rs
+++ b/school/programs/school/src/state/nft.rs
@@ -1,0 +1,46 @@
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    metadata::Metadata,
+    token::{Mint, Token, TokenAccount},
+};
+use mpl_token_metadata::accounts::{MasterEdition, Metadata as MetaDataAccount};
+
+#[derive(Accounts)]
+pub struct NFTAccounts<'info> {
+    #[account(
+        init,
+        payer = authority,
+        mint::decimals = 0,
+        mint::authority = authority.key(),
+        mint::freeze_authority = authority.key()
+    )]
+    pub mint: Account<'info, Mint>,
+
+    #[account(
+        init_if_needed,
+        payer = authority,
+        associated_token::mint = mint,
+        associated_token::authority = authority
+    )]
+    pub associated_token_account: Account<'info, TokenAccount>,
+
+    /// CHECK: Address is derived using a known PDA
+    #[account(mut, address=MetaDataAccount::find_pda(&mint.key()).0)]
+    pub metadata_account: AccountInfo<'info>,
+
+    /// CHECK: Address is derived using a known PDA
+    #[account(mut, address= MasterEdition::find_pda(&mint.key()).0)]
+    pub master_edition_account: AccountInfo<'info>,
+
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub token_program: Program<'info, Token>,
+    pub token_metadata_program: Program<'info, Metadata>,
+
+    pub rent: Sysvar<'info, Rent>,
+
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+}

--- a/school/programs/school/src/state/ratelimit.rs
+++ b/school/programs/school/src/state/ratelimit.rs
@@ -3,4 +3,5 @@ use anchor_lang::prelude::*;
 pub struct RateLimit {
     pub last_mint_time: i64,
     pub mint_count: u64,
+    pub bump: u8,
 }

--- a/school/programs/school/src/state/school.rs
+++ b/school/programs/school/src/state/school.rs
@@ -1,7 +1,5 @@
 use anchor_lang::prelude::*;
 
-use crate::constants::SchoolType;
-
 #[account]
 pub struct School {
     name: String,
@@ -10,19 +8,12 @@ pub struct School {
     class_count: u64,
     book_count: u64,
     student_count: u64,
-    school_type: SchoolType,
+    school_type: String,
     fee_multiplier: u64,
     bump: u8,
 }
 
 pub trait SchoolTrait {
-    fn new(
-        authority: Pubkey,
-        base_enrollment_fee: u64,
-        fee_multiplier: u64,
-        name: String,
-        school_type: SchoolType,
-    ) -> Self;
     fn get_name(&self) -> &str;
     fn get_authority(&self) -> Pubkey;
     fn get_enrollment_fee(&self) -> u64;
@@ -37,40 +28,20 @@ pub trait SchoolTrait {
     fn set_fee_multiplier(&mut self, new_multiplier: u64) -> Result<()>;
     fn set_authority(&mut self, new_authority: Pubkey);
     fn set_name(&mut self, name: String);
-    fn get_school_type(&self) -> SchoolType;
-    fn set_school_type(&mut self, school_type: SchoolType);
+    fn get_school_type(&self) -> &str;
+    fn set_school_type(&mut self, school_type: String);
     fn calculate_enrollment_fees(&self) -> Result<u64>;
     fn get_bump(&self) -> u8;
     fn set_bump(&mut self, bump: u8);
 }
 
 impl SchoolTrait for School {
-    fn new(
-        authority: Pubkey,
-        base_enrollment_fee: u64,
-        fee_multiplier: u64,
-        name: String,
-        school_type: SchoolType,
-    ) -> Self {
-        School {
-            authority,
-            base_enrollment_fee,
-            fee_multiplier,
-            name,
-            school_type,
-            class_count: 0,
-            book_count: 0,
-            student_count: 0,
-            bump: 0,
-        }
-    }
-
-    fn set_school_type(&mut self, school_type: SchoolType) {
+    fn set_school_type(&mut self, school_type: String) {
         self.school_type = school_type
     }
 
-    fn get_school_type(&self) -> SchoolType {
-        self.school_type
+    fn get_school_type(&self) -> &str {
+        &self.school_type
     }
 
     fn get_authority(&self) -> Pubkey {

--- a/school/programs/school/src/utils.rs
+++ b/school/programs/school/src/utils.rs
@@ -1,0 +1,18 @@
+use anchor_lang::prelude::*;
+
+use crate::constants::SchoolType;
+
+pub trait SchoolTypeTrait {
+    fn is_school_type(sch_type: &str) -> Result<bool>;
+}
+
+impl SchoolTypeTrait for SchoolType {
+    fn is_school_type(sch_type: &str) -> Result<bool> {
+        match sch_type.to_lowercase().as_str() {
+            "highschool" => Ok(true),
+            "college" => Ok(true),
+            "university" => Ok(true),
+            _ => Ok(false),
+        }
+    }
+}


### PR DESCRIPTION
- Introduce a new 'Course' struct to represent courses, including course name, NFT mint, capacity, and tuition fee 
- Update 'School' struct to remove school type enum and replace it with a string 
- Implement rate limiting on minting operations with a new 'RateLimit' struct 
- Introduce a new 'SchoolTypeTrait' to verify if a school type is valid 
- Update 'NFTCreator' trait to enforce rate limits and create NFT metadata accounts 
- Introduce a new 'NFTAccounts' struct to represent NFT accounts, including mint, associated token account, and metadata account